### PR TITLE
Fix some python 2/3 incompatabilities

### DIFF
--- a/removebg/__init__.py
+++ b/removebg/__init__.py
@@ -1,1 +1,2 @@
+from __future__ import absolute_import
 from removebg.removebg import RemoveBg

--- a/removebg/removebg.py
+++ b/removebg/removebg.py
@@ -1,10 +1,11 @@
+from __future__ import absolute_import
 import requests
 import logging
 
 API_ENDPOINT = "https://api.remove.bg/v1.0/removebg"
 
 
-class RemoveBg:
+class RemoveBg(object):
 
     def __init__(self, api_key, error_log_file):
         self.__api_key = api_key


### PR DESCRIPTION
This pull request resolves #2 .

In python2, imports are relative by default,[ this behavior changed as of python3.x](https://www.python.org/dev/peps/pep-0328/)
as of python2.5, a `__future__` import directive `absolute_import` exists to enable python3 behavior on python2x interpreters, resolving this issue.

This PR also resolves an incompatibility in in `RemoveBg`, caused by another change in behavior.
In python3, user classes are ["new-style classes"](https://www.python.org/doc/newstyle/) which automatically inherit from `object`, this is not the case in python2. 